### PR TITLE
Add async runtime and registry for skills

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ version = "0.1.0"
 description = "Demo skill execution framework"
 authors = [{name = "Demo"}]
 requires-python = ">=3.8"
-dependencies = []
+dependencies = [
+    "pydantic>=1.10,<2.0"
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/di_base_client/client.py
+++ b/src/di_base_client/client.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
-
 import logging
+from typing import Dict
 
 logger = logging.getLogger(__name__)
 
 
-class Client:
-    """Stub client that logs messages."""
+class DiBaseClient:
+    """Stub client that records results."""
 
-    def send(self, message: str) -> None:
-        logger.info("Client: %s", message)
+    def __init__(self) -> None:
+        self.results: Dict[str, Dict[str, str]] = {}
+
+    def log_result(self, instance_id: str, outputs: Dict[str, str]) -> None:
+        logger.info("Result %s: %s", instance_id, outputs)
+        self.results[instance_id] = outputs

--- a/src/di_core/api.py
+++ b/src/di_core/api.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
-
-from dataclasses import dataclass
-from typing import Any, Dict, Optional
-
-
-@dataclass
-class Request:
-    """Represents a skill execution request."""
-
-    name: str
-    params: Dict[str, Any]
+from pydantic import BaseModel, Field
+from typing import Dict, Literal
 
 
-@dataclass
-class Status:
-    """Result of executing a skill."""
+class ExecuteRequest(BaseModel):
+    skill_name: str
+    instance_id: str
+    params: Dict[str, str] = Field(default_factory=dict)
 
+
+Phase = Literal["QUEUED", "RUNNING", "COMPLETED", "FAILED", "ABORTED"]
+
+
+class ExecuteStatus(BaseModel):
+    instance_id: str
+    phase: Phase
+    message: str = ""
+    progress_pct: int = 0
+
+
+class ExecuteResult(BaseModel):
+    instance_id: str
     success: bool
-    result: Any = None
-    error: Optional[str] = None
+    outputs: Dict[str, str] = Field(default_factory=dict)
+    message: str = ""

--- a/src/di_core/registry.py
+++ b/src/di_core/registry.py
@@ -1,22 +1,25 @@
 from __future__ import annotations
-
-from typing import Dict, List, Optional, Type
-
-from di_skills.base import BaseSkill
-
-_registry: Dict[str, Type[BaseSkill]] = {}
+from typing import Dict, Type, List
+from di_skills.base import Skill
 
 
-def register(name: str, skill_cls: Type[BaseSkill]) -> None:
-    """Register a skill class under a name."""
-    _registry[name] = skill_cls
+class SkillRegistry:
+    def __init__(self) -> None:
+        self._skills: Dict[str, Type[Skill]] = {}
+
+    def register(self, cls: Type[Skill]):
+        name = getattr(cls, "NAME", cls.__name__)
+        self._skills[name] = cls
+        return cls
+
+    def get(self, name: str) -> Type[Skill]:
+        if name not in self._skills:
+            raise KeyError(f"Skill '{name}' not found")
+        return self._skills[name]
+
+    def list(self) -> List[str]:
+        return sorted(self._skills.keys())
 
 
-def get(name: str) -> Optional[Type[BaseSkill]]:
-    """Retrieve a skill class by name."""
-    return _registry.get(name)
-
-
-def list_skills() -> List[str]:
-    """Return the names of all registered skills."""
-    return sorted(_registry)
+# global registry instance
+registry = SkillRegistry()

--- a/src/di_core/runtime.py
+++ b/src/di_core/runtime.py
@@ -1,18 +1,61 @@
 from __future__ import annotations
+import asyncio
+from typing import AsyncIterator
+from di_core.api import ExecuteRequest, ExecuteStatus
+from di_core.registry import registry
+from di_skills.base import SkillContext
+from di_base_client.client import DiBaseClient
 
-from di_core.api import Request, Status
-from di_core.registry import get
 
+class Runtime:
+    def __init__(self) -> None:
+        self._tasks: dict[str, asyncio.Task] = {}
+        self._status_queues: dict[str, asyncio.Queue] = {}
+        self._dbase = DiBaseClient()
 
-def execute(request: Request) -> Status:
-    """Execute a skill based on the request."""
-    skill_cls = get(request.name)
-    if not skill_cls:
-        return Status(success=False, error=f"Skill '{request.name}' not found")
+    async def execute(self, req: ExecuteRequest) -> AsyncIterator[ExecuteStatus]:
+        # queue for streaming statuses to the caller
+        q: asyncio.Queue = asyncio.Queue()
+        self._status_queues[req.instance_id] = q
 
-    skill = skill_cls()
-    try:
-        result = skill.execute(**request.params)
-        return Status(success=True, result=result)
-    except Exception as exc:  # pragma: no cover - debug path
-        return Status(success=False, error=str(exc))
+        await q.put(ExecuteStatus(instance_id=req.instance_id, phase="QUEUED", message="queued", progress_pct=0))
+
+        async def _run():
+            try:
+                await q.put(ExecuteStatus(instance_id=req.instance_id, phase="RUNNING", message="starting", progress_pct=1))
+                skill_cls = registry.get(req.skill_name)
+                ctx = SkillContext(instance_id=req.instance_id, dbase=self._dbase, emit=lambda st: q.put_nowait(st))
+                skill = skill_cls()
+                await skill.precheck(ctx, req.params)
+                outputs = await skill.execute(ctx, req.params)
+                await q.put(ExecuteStatus(instance_id=req.instance_id, phase="COMPLETED", message="done", progress_pct=100))
+                self._dbase.log_result(req.instance_id, outputs)
+            except asyncio.CancelledError:
+                await q.put(ExecuteStatus(instance_id=req.instance_id, phase="ABORTED", message="aborted", progress_pct=0))
+                raise
+            except Exception as e:  # noqa: BLE001
+                await q.put(ExecuteStatus(instance_id=req.instance_id, phase="FAILED", message=str(e), progress_pct=0))
+            finally:
+                await asyncio.sleep(0)  # let consumer drain
+                q.put_nowait(None)  # sentinel for consumer
+                self._status_queues.pop(req.instance_id, None)
+                self._tasks.pop(req.instance_id, None)
+
+        task = asyncio.create_task(_run(), name=f"skill-{req.instance_id}")
+        self._tasks[req.instance_id] = task
+
+        while True:
+            st = await q.get()
+            if st is None:  # sentinel
+                break
+            yield st
+
+    def abort(self, instance_id: str) -> bool:
+        t = self._tasks.get(instance_id)
+        if t and not t.done():
+            t.cancel()
+            return True
+        return False
+
+    def list_instances(self):
+        return list(self._tasks.keys())

--- a/src/di_skills/base.py
+++ b/src/di_skills/base.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
-
 from abc import ABC, abstractmethod
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Callable, Dict
 
 
-class BaseSkill(ABC):
-    """Abstract base class for all skills."""
+@dataclass
+class SkillContext:
+    instance_id: str
+    dbase: Any
+    emit: Callable[[Any], None]
 
-    name: str
 
-    def __init__(self, **context: Any) -> None:
-        self.context = context
+class Skill(ABC):
+    """Base class for asynchronous skills."""
+
+    NAME: str
+
+    async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:
+        """Optional pre-execution checks."""
+        return None
 
     @abstractmethod
-    def execute(self, **kwargs: Any) -> Any:
-        """Run the skill's logic."""
+    async def execute(self, ctx: SkillContext, params: Dict[str, str]) -> Dict[str, str]:
+        """Run the skill's logic and return outputs."""
         raise NotImplementedError

--- a/src/di_skills/skills/unscrew.py
+++ b/src/di_skills/skills/unscrew.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-from di_core.registry import register
-from di_skills.base import BaseSkill
+from di_core.registry import registry
+from di_skills.base import Skill, SkillContext
 
 
-class UnscrewSkill(BaseSkill):
-    """Simple skill that returns a confirmation string."""
+@registry.register
+class UnscrewSkill(Skill):
+    """Simple skill that returns a confirmation output."""
 
-    name = "unscrew"
+    NAME = "unscrew"
 
-    def execute(self, **kwargs):  # type: ignore[override]
-        return "unscrewed"
-
-
-register(UnscrewSkill.name, UnscrewSkill)
+    async def execute(self, ctx: SkillContext, params: dict[str, str]):  # type: ignore[override]
+        return {"result": "unscrewed"}

--- a/tests/test_execute_unscrew.py
+++ b/tests/test_execute_unscrew.py
@@ -1,12 +1,17 @@
-from di_core.api import Request
-from di_core.registry import list_skills
-from di_core.runtime import execute
-import di_skills.skills.unscrew  # noqa: F401 - ensures registration
+import pytest
+from di_core.api import ExecuteRequest
+from di_core.runtime import Runtime
+from di_core.registry import registry
+import di_skills.skills.unscrew  # noqa: F401 - ensure registration
 
 
-def test_execute_unscrew():
-    assert "unscrew" in list_skills()
-    request = Request(name="unscrew", params={})
-    status = execute(request)
-    assert status.success
-    assert status.result == "unscrewed"
+@pytest.mark.asyncio
+async def test_execute_unscrew():
+    rt = Runtime()
+    req = ExecuteRequest(skill_name="unscrew", instance_id="abc123", params={})
+
+    statuses = [st async for st in rt.execute(req)]
+    assert [s.phase for s in statuses] == ["QUEUED", "RUNNING", "COMPLETED"]
+    assert registry.list() == ["unscrew"]
+    assert rt._dbase.results["abc123"] == {"result": "unscrewed"}
+    assert rt.list_instances() == []


### PR DESCRIPTION
## Summary
- Define Pydantic models for executing skills
- Introduce class-based skill registry and async runtime with streaming statuses
- Add async skill base and example unscrew skill; log results via stub client

## Testing
- `pip install pydantic==1.10.13`
- `pip install pytest-asyncio==0.23.8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b484360308331a308c6043e362893