### PR TITLE
feat: add async runtime and skills CLI

### DIFF
--- a/src/di_core/api.py
+++ b/src/di_core/api.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Dict
 
 
 @dataclass
-class Request:
-    """Represents a skill execution request."""
+class ExecuteRequest:
+    """Request to execute a skill."""
 
-    name: str
-    params: Dict[str, Any]
+    skill_name: str
+    instance_id: str
+    params: Dict[str, str]
 
 
 @dataclass
-class Status:
-    """Result of executing a skill."""
+class ExecuteStatus:
+    """Status update emitted during execution."""
 
-    success: bool
-    result: Any = None
-    error: Optional[str] = None
+    instance_id: str
+    phase: str
+    message: str
+    progress_pct: int

--- a/src/di_core/registry.py
+++ b/src/di_core/registry.py
@@ -1,22 +1,25 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Type, TYPE_CHECKING
 
-from di_skills.base import BaseSkill
-
-_registry: Dict[str, Type[BaseSkill]] = {}
-
-
-def register(name: str, skill_cls: Type[BaseSkill]) -> None:
-    """Register a skill class under a name."""
-    _registry[name] = skill_cls
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from di_skills.base import Skill
 
 
-def get(name: str) -> Optional[Type[BaseSkill]]:
-    """Retrieve a skill class by name."""
-    return _registry.get(name)
+class Registry:
+    """Simple in-memory registry for skills."""
+
+    def __init__(self) -> None:
+        self._skills: Dict[str, Type["Skill"]] = {}
+
+    def register(self, cls: Type["Skill"]) -> None:
+        self._skills[cls.NAME] = cls
+
+    def get(self, name: str):  # type: ignore[return-type]
+        return self._skills.get(name)
+
+    def list(self) -> List[str]:
+        return sorted(self._skills)
 
 
-def list_skills() -> List[str]:
-    """Return the names of all registered skills."""
-    return sorted(_registry)
+registry = Registry()

--- a/src/di_core/runtime.py
+++ b/src/di_core/runtime.py
@@ -1,18 +1,86 @@
 from __future__ import annotations
 
-from di_core.api import Request, Status
-from di_core.registry import get
+import asyncio
+import json
+from typing import AsyncGenerator, Dict
+
+from di_core.api import ExecuteRequest, ExecuteStatus
+from di_core.registry import registry
+from di_skills.base import SkillContext
 
 
-def execute(request: Request) -> Status:
-    """Execute a skill based on the request."""
-    skill_cls = get(request.name)
-    if not skill_cls:
-        return Status(success=False, error=f"Skill '{request.name}' not found")
+class Runtime:
+    """Runtime responsible for executing skills asynchronously."""
 
-    skill = skill_cls()
-    try:
-        result = skill.execute(**request.params)
-        return Status(success=True, result=result)
-    except Exception as exc:  # pragma: no cover - debug path
-        return Status(success=False, error=str(exc))
+    def __init__(self) -> None:
+        self._tasks: Dict[str, asyncio.Task] = {}
+
+    async def _run(self, req: ExecuteRequest, queue: asyncio.Queue[ExecuteStatus | None]) -> None:
+        skill_cls = registry.get(req.skill_name)
+        if not skill_cls:
+            await queue.put(
+                ExecuteStatus(
+                    instance_id=req.instance_id,
+                    phase="ERROR",
+                    message="skill not found",
+                    progress_pct=0,
+                )
+            )
+            await queue.put(None)
+            return
+
+        ctx = SkillContext(instance_id=req.instance_id, dbase=None, emit=queue.put_nowait)
+        skill = skill_cls()
+        try:
+            await skill.precheck(ctx, req.params)
+            outputs = await skill.execute(ctx, req.params)
+            await queue.put(
+                ExecuteStatus(
+                    instance_id=req.instance_id,
+                    phase="DONE",
+                    message=json.dumps(outputs),
+                    progress_pct=100,
+                )
+            )
+        except asyncio.CancelledError:
+            await queue.put(
+                ExecuteStatus(
+                    instance_id=req.instance_id,
+                    phase="ABORTED",
+                    message="aborted",
+                    progress_pct=100,
+                )
+            )
+            raise
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            await queue.put(
+                ExecuteStatus(
+                    instance_id=req.instance_id,
+                    phase="ERROR",
+                    message=str(exc),
+                    progress_pct=100,
+                )
+            )
+        finally:
+            await queue.put(None)
+
+    async def execute(self, req: ExecuteRequest) -> AsyncGenerator[ExecuteStatus, None]:
+        queue: asyncio.Queue[ExecuteStatus | None] = asyncio.Queue()
+        task = asyncio.create_task(self._run(req, queue))
+        self._tasks[req.instance_id] = task
+        try:
+            while True:
+                st = await queue.get()
+                if st is None:
+                    break
+                yield st
+        finally:
+            task.cancel()
+            self._tasks.pop(req.instance_id, None)
+
+    def abort(self, run_id: str) -> bool:
+        task = self._tasks.get(run_id)
+        if task and not task.done():
+            task.cancel()
+            return True
+        return False

--- a/src/di_skills/__init__.py
+++ b/src/di_skills/__init__.py
@@ -1,0 +1,1 @@
+from .base import Skill, SkillContext  # re-export

--- a/src/di_skills/base.py
+++ b/src/di_skills/base.py
@@ -1,18 +1,39 @@
 from __future__ import annotations
+import asyncio
+from typing import Dict, Callable
+from pydantic import BaseModel
+from di_core.api import ExecuteStatus
+from di_core.registry import registry
 
-from abc import ABC, abstractmethod
-from typing import Any
+
+class SkillContext(BaseModel):
+    instance_id: str
+    dbase: object
+    emit: Callable[[ExecuteStatus], None]
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    async def status(self, message: str, progress: int):
+        st = ExecuteStatus(instance_id=self.instance_id, phase="RUNNING", message=message, progress_pct=progress)
+        self.emit(st)
+        await asyncio.sleep(0)
 
 
-class BaseSkill(ABC):
-    """Abstract base class for all skills."""
+class Skill:
+    NAME: str = "Skill"
+    VERSION: str = "0.1.0"
 
-    name: str
+    async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:  # noqa: D401
+        """Override to implement safety/availability checks."""
+        return None
 
-    def __init__(self, **context: Any) -> None:
-        self.context = context
-
-    @abstractmethod
-    def execute(self, **kwargs: Any) -> Any:
-        """Run the skill's logic."""
+    async def execute(self, ctx: SkillContext, params: Dict[str, str]) -> Dict[str, str]:  # noqa: D401
+        """Override to perform the skill. Must return outputs as dict of strings."""
         raise NotImplementedError
+
+
+# decorator for registration
+def register(cls):
+    registry.register(cls)
+    return cls

--- a/src/di_skills/skills/unscrew.py
+++ b/src/di_skills/skills/unscrew.py
@@ -1,16 +1,29 @@
 from __future__ import annotations
+import asyncio
+from typing import Dict
+from di_skills.base import Skill, SkillContext, register
 
-from di_core.registry import register
-from di_skills.base import BaseSkill
+@register
+class Unscrew(Skill):
+    NAME = "Unscrew"
+    VERSION = "1.0.0"
 
+    async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:
+        target = params.get("target_id", "")
+        if not target:
+            raise ValueError("param 'target_id' is required")
+        await ctx.status(f"precheck ok for {target}", 5)
 
-class UnscrewSkill(BaseSkill):
-    """Simple skill that returns a confirmation string."""
-
-    name = "unscrew"
-
-    def execute(self, **kwargs):  # type: ignore[override]
-        return "unscrewed"
-
-
-register(UnscrewSkill.name, UnscrewSkill)
+    async def execute(self, ctx: SkillContext, params: Dict[str, str]) -> Dict[str, str]:
+        torque = params.get("torque", "5")
+        await ctx.status(f"move to {params['target_id']}", 15)
+        await asyncio.sleep(0.1)  # simulate motion
+        await ctx.status(f"set torque {torque}Nm", 25)
+        await asyncio.sleep(0.1)
+        # simulated unscrew steps
+        for i in range(5):
+            await ctx.status(f"unscrewing step {i+1}/5", 40 + i*10)
+            await asyncio.sleep(0.1)
+        await ctx.status("retract tool", 95)
+        await asyncio.sleep(0.1)
+        return {"removed": "true", "time_s": "0.7"}

--- a/tests/test_execute_unscrew.py
+++ b/tests/test_execute_unscrew.py
@@ -1,12 +1,24 @@
-from di_core.api import Request
-from di_core.registry import list_skills
-from di_core.runtime import execute
+import asyncio
+import json
+
 import di_skills.skills.unscrew  # noqa: F401 - ensures registration
+from di_core.api import ExecuteRequest
+from di_core.registry import registry
+from di_core.runtime import Runtime
 
 
 def test_execute_unscrew():
-    assert "unscrew" in list_skills()
-    request = Request(name="unscrew", params={})
-    status = execute(request)
-    assert status.success
-    assert status.result == "unscrewed"
+    assert "Unscrew" in registry.list()
+
+    async def run():
+        rt = Runtime()
+        req = ExecuteRequest(skill_name="Unscrew", instance_id="t1", params={"target_id": "bolt-1"})
+        statuses = []
+        async for st in rt.execute(req):
+            statuses.append(st)
+        return statuses
+
+    states = asyncio.run(run())
+    assert states[-1].phase == "DONE"
+    result = json.loads(states[-1].message)
+    assert result["removed"] == "true"


### PR DESCRIPTION
## Summary
- replace CLI with Typer-based interface for listing, executing, and aborting skills
- introduce pydantic-backed skill framework and registration decorator
- add asynchronous runtime, registry, API dataclasses, and Unscrew demo skill

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b48ab712083318a5015b4faeab63c