### PR TITLE
Add screw detection and localization skills with documentation

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,31 @@
+# Skill Documentation
+
+## DetectScrews (v1.0.0)
+Detect screws in an image and store their positions.
+
+**Inputs**
+- `image_path`: Path to the camera image
+
+**Outputs**
+- `screw_ids`: Comma separated screw identifiers
+
+## LocateScrew (v1.0.0)
+Move to a screw and refine its position via camera.
+
+**Inputs**
+- `screw_id`: Identifier of the screw to localize
+
+**Outputs**
+- `x`: Refined x position
+- `y`: Refined y position
+
+## Unscrew (v1.0.0)
+Remove a screw using a preset torque.
+
+**Inputs**
+- `target_id`: ID of the screw to remove
+- `torque`: Torque in Nm
+
+**Outputs**
+- `removed`: true if screw removed
+- `time_s`: time taken in seconds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 
 [project.scripts]
 dimonta = "di_core.cli:app"
+skill-docs = "di_skills.docgen:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/di_base_client/client.py
+++ b/src/di_base_client/client.py
@@ -1,3 +1,13 @@
 class DiBaseClient:
+    def __init__(self) -> None:
+        self._storage: dict[str, dict] = {}
+
+    def set(self, key: str, value):
+        self._storage[key] = value
+
+    def get(self, key: str, default=None):
+        return self._storage.get(key, default)
+
     def log_result(self, instance_id: str, outputs: dict):
+        self.set(instance_id, outputs)
         print(f"[di.base] {instance_id} -> {outputs}")

--- a/src/di_skills/__init__.py
+++ b/src/di_skills/__init__.py
@@ -1,6 +1,6 @@
 """Utilities and built-in skills for di.monta."""
 
 from .base import Skill, SkillContext
-from .skills import unscrew  # noqa: F401 - register Unscrew skill on import
+from . import skills  # noqa: F401 - register built-in skills
 
 __all__ = ["Skill", "SkillContext"]

--- a/src/di_skills/base.py
+++ b/src/di_skills/base.py
@@ -21,6 +21,8 @@ class SkillContext(BaseModel):
 class Skill:
     NAME: str = "Skill"
     VERSION: str = "0.1.0"
+    INPUTS: Dict[str, str] = {}
+    OUTPUTS: Dict[str, str] = {}
 
     async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:  # noqa: D401
         """Override to implement safety/availability checks."""

--- a/src/di_skills/docgen.py
+++ b/src/di_skills/docgen.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import inspect
+from pathlib import Path
+from di_core.registry import registry
+from . import skills  # ensure all skills are registered
+
+
+def generate_docs(dest: Path) -> str:
+    lines = ["# Skill Documentation", ""]
+    for name in registry.list():
+        cls = registry.get(name)
+        lines.append(f"## {cls.NAME} (v{cls.VERSION})")
+        doc = inspect.getdoc(cls) or ""
+        if doc:
+            lines.append(doc)
+            lines.append("")
+        inputs = getattr(cls, "INPUTS", {})
+        if inputs:
+            lines.append("**Inputs**")
+            for k, v in inputs.items():
+                lines.append(f"- `{k}`: {v}")
+            lines.append("")
+        outputs = getattr(cls, "OUTPUTS", {})
+        if outputs:
+            lines.append("**Outputs**")
+            for k, v in outputs.items():
+                lines.append(f"- `{k}`: {v}")
+            lines.append("")
+    content = "\n".join(lines).strip() + "\n"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(content)
+    return content
+
+
+def main() -> None:
+    doc_path = Path(__file__).resolve().parents[2] / "docs" / "skills.md"
+    generate_docs(doc_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/di_skills/skills/__init__.py
+++ b/src/di_skills/skills/__init__.py
@@ -1,0 +1,3 @@
+from .unscrew import Unscrew  # noqa: F401
+from .detect_screws import DetectScrews  # noqa: F401
+from .locate_screw import LocateScrew  # noqa: F401

--- a/src/di_skills/skills/detect_screws.py
+++ b/src/di_skills/skills/detect_screws.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+import asyncio
+from typing import Dict
+from di_skills.base import Skill, SkillContext, register
+
+@register
+class DetectScrews(Skill):
+    """Detect screws in an image and store their positions."""
+
+    NAME = "DetectScrews"
+    VERSION = "1.0.0"
+    INPUTS = {"image_path": "Path to the camera image"}
+    OUTPUTS = {"screw_ids": "Comma separated screw identifiers"}
+
+    async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:
+        if not params.get("image_path"):
+            raise ValueError("param 'image_path' is required")
+        await ctx.status("image received", 5)
+
+    async def execute(self, ctx: SkillContext, params: Dict[str, str]) -> Dict[str, str]:
+        await ctx.status("processing image", 20)
+        await asyncio.sleep(0.1)
+        # simulated detection result
+        screws = {"S1": (10.0, 20.0), "S2": (30.0, 40.0)}
+        ctx.dbase.set("screw_positions", screws)
+        await ctx.status("screws detected", 90)
+        await asyncio.sleep(0.1)
+        return {"screw_ids": ",".join(screws.keys())}

--- a/src/di_skills/skills/locate_screw.py
+++ b/src/di_skills/skills/locate_screw.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import asyncio
+from typing import Dict
+from di_skills.base import Skill, SkillContext, register
+
+@register
+class LocateScrew(Skill):
+    """Move to a screw and refine its position via camera."""
+
+    NAME = "LocateScrew"
+    VERSION = "1.0.0"
+    INPUTS = {"screw_id": "Identifier of the screw to localize"}
+    OUTPUTS = {"x": "Refined x position", "y": "Refined y position"}
+
+    async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:
+        sid = params.get("screw_id")
+        screws = ctx.dbase.get("screw_positions", {}) or {}
+        if not sid:
+            raise ValueError("param 'screw_id' is required")
+        if sid not in screws:
+            raise ValueError("unknown screw_id")
+        await ctx.status("precheck ok", 5)
+
+    async def execute(self, ctx: SkillContext, params: Dict[str, str]) -> Dict[str, str]:
+        sid = params["screw_id"]
+        screws = ctx.dbase.get("screw_positions", {}) or {}
+        coarse = screws[sid]
+        await ctx.status(f"move to {sid}", 20)
+        await asyncio.sleep(0.1)
+        refined = (coarse[0] + 0.5, coarse[1] - 0.2)
+        screws[sid] = refined
+        ctx.dbase.set("screw_positions", screws)
+        await ctx.status("position refined", 90)
+        await asyncio.sleep(0.1)
+        return {"x": str(refined[0]), "y": str(refined[1])}

--- a/tests/test_screw_workflow.py
+++ b/tests/test_screw_workflow.py
@@ -1,0 +1,31 @@
+import asyncio
+from di_core.api import ExecuteRequest
+from di_core.runtime import Runtime
+
+
+async def _collect_statuses(rt, req):
+    events = []
+    async for st in rt.execute(req):
+        events.append(st)
+    return events
+
+
+def test_full_workflow():
+    rt = Runtime()
+    # detect screws
+    req1 = ExecuteRequest(skill_name="DetectScrews", instance_id="d1", params={"image_path": "img.png"})
+    asyncio.run(_collect_statuses(rt, req1))
+    screws = rt._dbase.get("screw_positions")
+    assert screws and "S1" in screws
+
+    # refine position for S1
+    req2 = ExecuteRequest(skill_name="LocateScrew", instance_id="l1", params={"screw_id": "S1"})
+    asyncio.run(_collect_statuses(rt, req2))
+    refined = rt._dbase.get("screw_positions")["S1"]
+    assert isinstance(refined, tuple)
+
+    # unscrew S1
+    req3 = ExecuteRequest(skill_name="Unscrew", instance_id="u1", params={"target_id": "S1", "torque": "5"})
+    events = asyncio.run(_collect_statuses(rt, req3))
+    assert any(e.phase == "COMPLETED" for e in events)
+    assert "S1" not in rt._dbase.get("screw_positions")


### PR DESCRIPTION
## Summary
- add DetectScrews and LocateScrew skills that record positions in di.base
- extend Unscrew to use stored screw positions
- generate human-readable skill docs via `skill-docs`

## Testing
- `PYTHONPATH=src pytest`
- `PYTHONPATH=src python -m di_skills.docgen`


------
https://chatgpt.com/codex/tasks/task_e_689b57022cc0833191b9b9c8f9fe1ed9