### PR TITLE
Add persistent base storage and dismantling planner skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Demo Skills Framework
 
-Minimal framework for registering and executing skills. Includes an example
-`unscrew` skill and a tiny runtime with CLI support.
+Minimal framework for registering and executing skills. Includes example
+skills for detecting, locating and unscrewing screws as well as a simple
+`DismantlingPlanner`. A tiny runtime with CLI support persists data via a
+miniature `di.base` database which can be inspected using `dimonta db show`.

--- a/src/di_base_client/client.py
+++ b/src/di_base_client/client.py
@@ -1,13 +1,36 @@
-class DiBaseClient:
-    def __init__(self) -> None:
-        self._storage: dict[str, dict] = {}
+from __future__ import annotations
 
-    def set(self, key: str, value):
+import json
+from pathlib import Path
+
+
+class DiBaseClient:
+    """Very small persistent key/value store for skills."""
+
+    def __init__(self, path: str | Path = "/tmp/di_base.json") -> None:
+        self._path = Path(path)
+        if self._path.exists():
+            try:
+                self._storage: dict[str, dict] = json.loads(self._path.read_text())
+            except Exception:  # noqa: BLE001 - best effort load
+                self._storage = {}
+        else:
+            self._storage = {}
+
+    def _save(self) -> None:
+        self._path.write_text(json.dumps(self._storage))
+
+    def set(self, key: str, value) -> None:
         self._storage[key] = value
+        self._save()
 
     def get(self, key: str, default=None):
         return self._storage.get(key, default)
 
-    def log_result(self, instance_id: str, outputs: dict):
+    def dump(self) -> dict[str, dict]:
+        """Return the entire storage for inspection."""
+        return self._storage
+
+    def log_result(self, instance_id: str, outputs: dict) -> None:
         self.set(instance_id, outputs)
         print(f"[di.base] {instance_id} -> {outputs}")

--- a/src/di_core/cli.py
+++ b/src/di_core/cli.py
@@ -11,7 +11,9 @@ from di_skills.skills import unscrew as _  # noqa: F401
 
 app = typer.Typer(help="di.core MVP CLI")
 skills_app = typer.Typer(help="Manage skills")
+db_app = typer.Typer(help="Inspect database")
 app.add_typer(skills_app, name="skills")
+app.add_typer(db_app, name="db")
 
 @skills_app.command("list")
 def skills_list():
@@ -54,6 +56,13 @@ def skills_abort(instance_id: str):
     rt = Runtime()
     ok = rt.abort(instance_id)
     typer.echo("aborted" if ok else "not found or already finished")
+
+
+@db_app.command("show")
+def db_show():
+    """Print current contents of the database."""
+    rt = Runtime()
+    typer.echo(json.dumps(rt._dbase.dump(), indent=2))
 
 if __name__ == "__main__":
     app()

--- a/src/di_skills/skills/__init__.py
+++ b/src/di_skills/skills/__init__.py
@@ -1,3 +1,4 @@
 from .unscrew import Unscrew  # noqa: F401
 from .detect_screws import DetectScrews  # noqa: F401
 from .locate_screw import LocateScrew  # noqa: F401
+from .dismantling_planner import DismantlingPlanner  # noqa: F401

--- a/src/di_skills/skills/detect_screws.py
+++ b/src/di_skills/skills/detect_screws.py
@@ -21,8 +21,11 @@ class DetectScrews(Skill):
         await ctx.status("processing image", 20)
         await asyncio.sleep(0.1)
         # simulated detection result
-        screws = {"S1": (10.0, 20.0), "S2": (30.0, 40.0)}
-        ctx.dbase.set("screw_positions", screws)
+        screws = {
+            "S1": {"x": 10.0, "y": 20.0, "dismantled": True},
+            "S2": {"x": 30.0, "y": 40.0, "dismantled": True},
+        }
+        ctx.dbase.set("screws", screws)
         await ctx.status("screws detected", 90)
         await asyncio.sleep(0.1)
         return {"screw_ids": ",".join(screws.keys())}

--- a/src/di_skills/skills/dismantling_planner.py
+++ b/src/di_skills/skills/dismantling_planner.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+import asyncio
+import random
+from typing import Dict
+from di_skills.base import Skill, SkillContext, register
+
+@register
+class DismantlingPlanner(Skill):
+    """Plan a random sequence of screws to dismantle."""
+
+    NAME = "DismantlingPlanner"
+    VERSION = "1.0.0"
+    INPUTS: Dict[str, str] = {}
+    OUTPUTS = {"plan": "Comma separated screw identifiers"}
+
+    async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:
+        screws = ctx.dbase.get("screws", {}) or {}
+        if not screws:
+            raise ValueError("no screws available")
+        await ctx.status("planning", 5)
+
+    async def execute(self, ctx: SkillContext, params: Dict[str, str]) -> Dict[str, str]:
+        await ctx.status("collecting", 20)
+        await asyncio.sleep(0.1)
+        screws = ctx.dbase.get("screws", {}) or {}
+        ids = [sid for sid, info in screws.items() if info.get("dismantled")]
+        random.shuffle(ids)
+        await ctx.status("plan ready", 90)
+        await asyncio.sleep(0.1)
+        return {"plan": ",".join(ids)}

--- a/src/di_skills/skills/locate_screw.py
+++ b/src/di_skills/skills/locate_screw.py
@@ -14,22 +14,22 @@ class LocateScrew(Skill):
 
     async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:
         sid = params.get("screw_id")
-        screws = ctx.dbase.get("screw_positions", {}) or {}
+        screws = ctx.dbase.get("screws", {}) or {}
         if not sid:
             raise ValueError("param 'screw_id' is required")
-        if sid not in screws:
+        if sid not in screws or not screws[sid].get("dismantled", False):
             raise ValueError("unknown screw_id")
         await ctx.status("precheck ok", 5)
 
     async def execute(self, ctx: SkillContext, params: Dict[str, str]) -> Dict[str, str]:
         sid = params["screw_id"]
-        screws = ctx.dbase.get("screw_positions", {}) or {}
+        screws = ctx.dbase.get("screws", {}) or {}
         coarse = screws[sid]
         await ctx.status(f"move to {sid}", 20)
         await asyncio.sleep(0.1)
-        refined = (coarse[0] + 0.5, coarse[1] - 0.2)
-        screws[sid] = refined
-        ctx.dbase.set("screw_positions", screws)
+        refined = (coarse["x"] + 0.5, coarse["y"] - 0.2)
+        screws[sid]["x"], screws[sid]["y"] = refined
+        ctx.dbase.set("screws", screws)
         await ctx.status("position refined", 90)
         await asyncio.sleep(0.1)
         return {"x": str(refined[0]), "y": str(refined[1])}

--- a/tests/test_execute_unscrew.py
+++ b/tests/test_execute_unscrew.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 from di_core.api import ExecuteRequest
 from di_core.runtime import Runtime
 
@@ -9,8 +10,10 @@ async def _collect_statuses(rt, req):
     return events
 
 def test_unscrew_runs():
-    req = ExecuteRequest(skill_name="Unscrew", instance_id="t1", params={"target_id":"A1","torque":"5"})
+    Path("/tmp/di_base.json").unlink(missing_ok=True)
     rt = Runtime()
+    rt._dbase.set("screws", {"A1": {"x": 0, "y": 0, "dismantled": True}})
+    req = ExecuteRequest(skill_name="Unscrew", instance_id="t1", params={"target_id": "A1", "torque": "5"})
     events = asyncio.run(_collect_statuses(rt, req))
     assert events[0].phase == "QUEUED"
     assert any(e.phase == "COMPLETED" for e in events)

--- a/tests/test_screw_workflow.py
+++ b/tests/test_screw_workflow.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 from di_core.api import ExecuteRequest
 from di_core.runtime import Runtime
 
@@ -11,21 +12,28 @@ async def _collect_statuses(rt, req):
 
 
 def test_full_workflow():
+    Path("/tmp/di_base.json").unlink(missing_ok=True)
     rt = Runtime()
     # detect screws
     req1 = ExecuteRequest(skill_name="DetectScrews", instance_id="d1", params={"image_path": "img.png"})
     asyncio.run(_collect_statuses(rt, req1))
-    screws = rt._dbase.get("screw_positions")
-    assert screws and "S1" in screws
+    screws = rt._dbase.get("screws")
+    assert screws and "S1" in screws and screws["S1"]["dismantled"]
 
     # refine position for S1
     req2 = ExecuteRequest(skill_name="LocateScrew", instance_id="l1", params={"screw_id": "S1"})
     asyncio.run(_collect_statuses(rt, req2))
-    refined = rt._dbase.get("screw_positions")["S1"]
-    assert isinstance(refined, tuple)
+    refined = rt._dbase.get("screws")["S1"]
+    assert isinstance(refined, dict) and refined["dismantled"]
 
     # unscrew S1
     req3 = ExecuteRequest(skill_name="Unscrew", instance_id="u1", params={"target_id": "S1", "torque": "5"})
     events = asyncio.run(_collect_statuses(rt, req3))
     assert any(e.phase == "COMPLETED" for e in events)
-    assert "S1" not in rt._dbase.get("screw_positions")
+    assert not rt._dbase.get("screws")["S1"]["dismantled"]
+
+    # planner should now only return remaining screws
+    req4 = ExecuteRequest(skill_name="DismantlingPlanner", instance_id="p1", params={})
+    res_events = asyncio.run(_collect_statuses(rt, req4))
+    plan = rt._dbase.get("p1")["plan"].split(",") if rt._dbase.get("p1") else []
+    assert "S1" not in plan and "S2" in plan


### PR DESCRIPTION
## Summary
- persist di.base data to a json file and expose dump
- track screws with `dismantled` flag and update detect/locate/unscrew accordingly
- add DismantlingPlanner skill and CLI command to view database

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b5e2ffb8083319c0f0d6279929e49