### PR TITLE
feat: print skill docs to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,63 @@ Minimal framework for registering and executing skills. Includes example
 skills for detecting, locating and unscrewing screws as well as a simple
 `DismantlingPlanner`. A tiny runtime with CLI support persists data via a
 miniature `di.base` database which can be inspected using `dimonta db show`.
+
+## Installation
+
+Install the latest version directly from GitHub:
+
+```bash
+pip install git+https://github.com/SzIGMR/demondemoskills2.git
+```
+
+This provides the `dimonta` CLI for running and inspecting skills and a
+`skill-docs` helper to regenerate the documentation in `docs/skills.md`.
+
+## Usage
+
+List the available skills:
+
+```bash
+dimonta skills list
+```
+
+Execute a skill (parameters can be passed as `key=value` pairs):
+
+```bash
+dimonta skills exec DetectScrews -p image_path=img.png
+```
+
+Inspect the small in-memory database:
+
+```bash
+dimonta db show
+```
+
+## Demo Ideas
+
+- **Full Screw Workflow** – Run a sequence of skills to detect screws,
+  refine the position of one screw and remove it:
+
+  ```bash
+  dimonta skills exec DetectScrews -p image_path=img.png
+  dimonta skills exec LocateScrew -p screw_id=S1
+  dimonta skills exec Unscrew -p target_id=S1 -p torque=5
+  dimonta skills exec DismantlingPlanner
+  ```
+
+- **Generate Skill Documentation** – Recreate the markdown overview of
+  available skills:
+
+  ```bash
+  skill-docs > docs/skills.md
+  ```
+
+  The command prints the markdown to `stdout`, so you may also supply a
+  destination path directly:
+
+  ```bash
+  skill-docs docs/skills.md
+  ```
+
+These examples are a starting point for experimenting with new skills or
+building larger robotic workflows on top of the framework.

--- a/src/di_skills/docgen.py
+++ b/src/di_skills/docgen.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
+
+import argparse
 import inspect
+import sys
 from pathlib import Path
+
 from di_core.registry import registry
 from . import skills  # ensure all skills are registered
 
 
-def generate_docs(dest: Path) -> str:
+def generate_docs() -> str:
+    """Generate markdown documentation for all registered skills."""
+
     lines = ["# Skill Documentation", ""]
     for name in registry.list():
         cls = registry.get(name)
@@ -26,15 +32,27 @@ def generate_docs(dest: Path) -> str:
             for k, v in outputs.items():
                 lines.append(f"- `{k}`: {v}")
             lines.append("")
-    content = "\n".join(lines).strip() + "\n"
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(content)
-    return content
+    return "\n".join(lines).strip() + "\n"
 
 
 def main() -> None:
-    doc_path = Path(__file__).resolve().parents[2] / "docs" / "skills.md"
-    generate_docs(doc_path)
+    """CLI entry point for generating skill documentation."""
+
+    parser = argparse.ArgumentParser(description="Generate skill documentation")
+    parser.add_argument(
+        "dest",
+        nargs="?",
+        help="Optional path to write markdown output. If omitted, prints to stdout.",
+    )
+    args = parser.parse_args()
+
+    content = generate_docs()
+    if args.dest:
+        path = Path(args.dest)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    else:
+        sys.stdout.write(content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- print skill documentation to stdout in the `skill-docs` CLI
- allow optional output path and document usage in README

## Testing
- `python -m di_skills.docgen | head -n 20`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6680b1048331806e87f728900b72