### PR TITLE
Add RealSense capture skill and YOLO-ready detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,8 @@ Open ``http://localhost:8000`` in your browser and adjust the JSON as needed.
 
 These examples are a starting point for experimenting with new skills or
 building larger robotic workflows on top of the framework.
+
+## Additional Hardware/Model Setup
+
+- [RealSense camera instructions](docs/realsense.md)
+- [YOLO model instructions](docs/yolo.md)

--- a/docs/realsense.md
+++ b/docs/realsense.md
@@ -1,0 +1,14 @@
+# RealSense Setup
+
+The `CaptureRealSenseImage` skill can acquire a frame from an Intel RealSense camera.
+To use a physical camera:
+
+1. Install the `pyrealsense2` drivers and ensure the device is connected via USB.
+2. Execute the skill with the parameter `use_camera=true`:
+   ```bash
+   dimonta skills exec CaptureRealSenseImage -p use_camera=true
+   ```
+3. The captured image is stored in the database under the key `camera_image`.
+
+If no camera is available, omit the parameter or set `use_camera=false`.
+A small dummy image will be written to the database so dependent skills can still run.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,13 +1,30 @@
 # Skill Documentation
 
-## DetectScrews (v1.0.0)
+## CaptureRealSenseImage (v1.1.0)
+Capture an image from an Intel RealSense camera and store it in the database.
+
+**Inputs**
+- `use_camera`: Set to `true` to read from a RealSense camera, otherwise a dummy image is produced
+
+**Outputs**
+- `image_key`: Database key where the image is stored
+
+## DetectScrews (v1.2.0)
 Detect screws in an image and store their positions.
 
 **Inputs**
-- `image_path`: Path to the camera image
+- `image_path`: Path to the camera image (optional if image is stored in db)
+- `model_path`: Optional path to a YOLOv8 model
+- `use_model`: Set to `true` to run a YOLOv8 model, otherwise a simulated detection is returned
 
 **Outputs**
 - `screw_ids`: Comma separated screw identifiers
+
+## DismantlingPlanner (v1.0.0)
+Plan a random sequence of screws to dismantle.
+
+**Outputs**
+- `plan`: Comma separated screw identifiers
 
 ## LocateScrew (v1.0.0)
 Move to a screw and refine its position via camera.
@@ -18,6 +35,16 @@ Move to a screw and refine its position via camera.
 **Outputs**
 - `x`: Refined x position
 - `y`: Refined y position
+
+## ScrewRemovalWorkflow (v1.0.0)
+Run detection, planning and removal of all screws using a behavior tree.
+
+**Inputs**
+- `image_path`: Path to the camera image
+- `torque`: Torque in Nm
+
+**Outputs**
+- `removed_ids`: Comma separated removed screw identifiers
 
 ## Unscrew (v1.0.0)
 Remove a screw using a preset torque.

--- a/docs/yolo.md
+++ b/docs/yolo.md
@@ -1,0 +1,15 @@
+# YOLO Model Setup
+
+The `DetectScrews` skill can run a YOLOv8 model to locate screws in an image.
+
+To use a real model:
+
+1. Install the `ultralytics` package and download a YOLOv8 weight file (e.g. `yolov8n.pt`).
+2. Execute the skill with `use_model=true` and optionally provide a custom `model_path`:
+   ```bash
+   dimonta skills exec DetectScrews -p use_model=true -p model_path=/path/to/model.pt
+   ```
+3. Detected screw positions are stored in the database under the key `screws`.
+
+If a model is not available, omit the parameter or set `use_model=false`.
+The skill will return a simulated detection so that workflows can continue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
   "typer>=0.9",
   "fastapi>=0.95,<0.100",
   "uvicorn>=0.23",
+  "pyrealsense2",
+  "opencv-python",
+  "ultralytics",
 ]
 
 [project.scripts]

--- a/src/di_skills/skills/__init__.py
+++ b/src/di_skills/skills/__init__.py
@@ -3,3 +3,4 @@ from .detect_screws import DetectScrews  # noqa: F401
 from .locate_screw import LocateScrew  # noqa: F401
 from .dismantling_planner import DismantlingPlanner  # noqa: F401
 from .screw_removal_bt import ScrewRemovalWorkflow  # noqa: F401
+from .capture_realsense_image import CaptureRealSenseImage  # noqa: F401

--- a/src/di_skills/skills/capture_realsense_image.py
+++ b/src/di_skills/skills/capture_realsense_image.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+import asyncio
+import base64
+from typing import Dict
+from di_skills.base import Skill, SkillContext, register
+
+try:  # pragma: no cover - optional hardware libraries
+    import pyrealsense2 as rs  # type: ignore
+    import numpy as np
+    import cv2
+except Exception:  # noqa: BLE001
+    rs = None  # type: ignore
+    np = None  # type: ignore
+    cv2 = None  # type: ignore
+
+
+PIXEL = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+BFQAE/wH+5Jr4GAAAAABJRU5ErkJggg=="
+)
+
+
+@register
+class CaptureRealSenseImage(Skill):
+    """Capture an image from an Intel RealSense camera and store it in the database."""
+
+    NAME = "CaptureRealSenseImage"
+    VERSION = "1.1.0"
+    INPUTS: Dict[str, str] = {
+        "use_camera": "Set to 'true' to read from a RealSense camera, otherwise a dummy image is stored",
+    }
+    OUTPUTS = {"image_key": "Database key where the image is stored"}
+
+    async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:
+        if params.get("use_camera", "false").lower() != "true":
+            await ctx.status("using dummy image", 5)
+            return
+        if rs is None or np is None or cv2 is None:  # pragma: no cover - import check
+            raise RuntimeError(
+                "pyrealsense2 and opencv-python are required to capture images"
+            )
+        await ctx.status("camera ready", 5)
+
+    async def execute(self, ctx: SkillContext, params: Dict[str, str]) -> Dict[str, str]:  # pragma: no cover - hardware interaction
+        if params.get("use_camera", "false").lower() == "true" and rs and np and cv2:
+            pipeline = rs.pipeline()
+            config = rs.config()
+            config.enable_stream(rs.stream.color, 640, 480, rs.format.bgr8, 30)
+            pipeline.start(config)
+            try:
+                frames = pipeline.wait_for_frames()
+                color_frame = frames.get_color_frame()
+                image = np.asanyarray(color_frame.get_data())
+            finally:
+                pipeline.stop()
+            _, buf = cv2.imencode(".png", image)
+            data_b64 = base64.b64encode(buf.tobytes()).decode()
+        else:
+            data_b64 = PIXEL
+        ctx.dbase.set("camera_image", {"format": "png", "data": data_b64})
+        await ctx.status("image captured", 95)
+        await asyncio.sleep(0.1)
+        return {"image_key": "camera_image"}

--- a/src/di_skills/skills/detect_screws.py
+++ b/src/di_skills/skills/detect_screws.py
@@ -1,30 +1,71 @@
 from __future__ import annotations
 import asyncio
+import base64
 from typing import Dict
 from di_skills.base import Skill, SkillContext, register
+
+try:  # pragma: no cover - optional model libraries
+    from ultralytics import YOLO  # type: ignore
+    import cv2
+    import numpy as np
+except Exception:  # noqa: BLE001
+    YOLO = None  # type: ignore
+    cv2 = None  # type: ignore
+    np = None  # type: ignore
+
 
 @register
 class DetectScrews(Skill):
     """Detect screws in an image and store their positions."""
 
     NAME = "DetectScrews"
-    VERSION = "1.0.0"
-    INPUTS = {"image_path": "Path to the camera image"}
+    VERSION = "1.2.0"
+    INPUTS = {
+        "image_path": "Path to the camera image (optional if image is stored in db)",
+        "model_path": "Optional path to a YOLOv8 model",
+        "use_model": "Set to 'true' to run a YOLOv8 model, otherwise a simulated detection is returned",
+    }
     OUTPUTS = {"screw_ids": "Comma separated screw identifiers"}
 
     async def precheck(self, ctx: SkillContext, params: Dict[str, str]) -> None:
-        if not params.get("image_path"):
-            raise ValueError("param 'image_path' is required")
+        if not params.get("image_path") and not ctx.dbase.get("camera_image"):
+            raise ValueError("image_path param or database image is required")
+        if params.get("use_model", "false").lower() == "true":
+            if YOLO is None or cv2 is None or np is None:
+                raise RuntimeError(
+                    "ultralytics, opencv-python and numpy are required to run YOLO models"
+                )
         await ctx.status("image received", 5)
 
     async def execute(self, ctx: SkillContext, params: Dict[str, str]) -> Dict[str, str]:
         await ctx.status("processing image", 20)
         await asyncio.sleep(0.1)
-        # simulated detection result
-        screws = {
-            "S1": {"x": 10.0, "y": 20.0, "dismantled": True},
-            "S2": {"x": 30.0, "y": 40.0, "dismantled": True},
-        }
+        image = None
+        if params.get("image_path") and cv2 is not None:
+            image = cv2.imread(params["image_path"])
+        elif cv2 is not None and np is not None:
+            entry = ctx.dbase.get("camera_image")
+            if entry:
+                data = base64.b64decode(entry.get("data", ""))
+                image = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
+
+        use_model = params.get("use_model", "false").lower() == "true"
+        screws: Dict[str, Dict[str, float | bool]]
+        if image is not None and use_model and YOLO is not None:
+            model = YOLO(params.get("model_path", "yolov8n.pt"))
+            results = model(image)
+            screws = {}
+            boxes = results[0].boxes.xyxy.tolist() if results else []
+            for i, box in enumerate(boxes, start=1):
+                x_center = (box[0] + box[2]) / 2.0
+                y_center = (box[1] + box[3]) / 2.0
+                screws[f"S{i}"] = {"x": float(x_center), "y": float(y_center), "dismantled": True}
+        else:
+            # simulated detection result when model or image not available
+            screws = {
+                "S1": {"x": 10.0, "y": 20.0, "dismantled": True},
+                "S2": {"x": 30.0, "y": 40.0, "dismantled": True},
+            }
         ctx.dbase.set("screws", screws)
         await ctx.status("screws detected", 90)
         await asyncio.sleep(0.1)

--- a/tests/test_capture_dummy.py
+++ b/tests/test_capture_dummy.py
@@ -1,0 +1,20 @@
+import asyncio
+from pathlib import Path
+from di_core.api import ExecuteRequest
+from di_core.runtime import Runtime
+
+async def _collect_statuses(rt, req):
+    events = []
+    async for st in rt.execute(req):
+        events.append(st)
+    return events
+
+
+def test_capture_dummy_image():
+    Path("/tmp/di_base.json").unlink(missing_ok=True)
+    rt = Runtime()
+    req = ExecuteRequest(skill_name="CaptureRealSenseImage", instance_id="c1", params={})
+    events = asyncio.run(_collect_statuses(rt, req))
+    assert any(e.phase == "COMPLETED" for e in events)
+    entry = rt._dbase.get("camera_image")
+    assert entry and entry.get("data")

--- a/tests/test_detect_from_db.py
+++ b/tests/test_detect_from_db.py
@@ -1,0 +1,22 @@
+import asyncio
+from pathlib import Path
+from di_core.api import ExecuteRequest
+from di_core.runtime import Runtime
+
+PIXEL = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+BFQAE/wH+5Jr4GAAAAABJRU5ErkJggg=="
+
+async def _collect_statuses(rt, req):
+    events = []
+    async for st in rt.execute(req):
+        events.append(st)
+    return events
+
+def test_detect_screws_from_db():
+    Path("/tmp/di_base.json").unlink(missing_ok=True)
+    rt = Runtime()
+    rt._dbase.set("camera_image", {"format": "png", "data": PIXEL})
+    req = ExecuteRequest(skill_name="DetectScrews", instance_id="d1", params={})
+    events = asyncio.run(_collect_statuses(rt, req))
+    assert any(e.phase == "COMPLETED" for e in events)
+    screws = rt._dbase.get("screws")
+    assert screws and "S1" in screws


### PR DESCRIPTION
## Summary
- add CaptureRealSenseImage skill to grab frames from a RealSense camera and cache them in the DB
- enhance DetectScrews to pull images from DB and optionally run YOLOv8
- include RealSense/YOLO dependencies and document new skill
- document RealSense and YOLO setup with optional dummy modes, linking from README

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c4879ea1c8331a27c09fc7f71b1f3