### PR TITLE
Add web viewer for YOLO detection results

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ dimonta web config --port 8000
 
 Open ``http://localhost:8000`` in your browser and adjust the JSON as needed.
 
+### YOLO Result Viewer
+
+After running detection skills you can inspect the stored image and screw
+positions in a simple browser-based UI:
+
+```bash
+dimonta web results --port 8001
+```
+
+Open ``http://localhost:8001`` to view the image with annotated detections and
+their coordinates.
+
 ## Demo Ideas
 
 - **Manual Full Screw Workflow** – Run a sequence of skills to detect screws,

--- a/src/di_core/cli.py
+++ b/src/di_core/cli.py
@@ -78,6 +78,16 @@ def web_config(host: str = "localhost", port: int = 8000):
 
     uvicorn.run(webapp, host=host, port=port)
 
+
+@web_app.command("results")
+def web_results(host: str = "localhost", port: int = 8001):
+    """Launch the detection results web UI."""
+
+    import uvicorn
+    from di_core.results_web import app as webapp
+
+    uvicorn.run(webapp, host=host, port=port)
+
 app.add_typer(web_app, name="web")
 
 

--- a/src/di_core/results_web.py
+++ b/src/di_core/results_web.py
@@ -1,0 +1,74 @@
+"""Simple FastAPI app for viewing detection results."""
+from __future__ import annotations
+
+import base64
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, Response
+
+from di_base_client.client import DiBaseClient
+from di_core.config import config_manager
+
+
+dbase = DiBaseClient(path=config_manager.config.database.path)
+app = FastAPI(title="di.core results")
+
+
+@app.get("/screws")
+def get_screws():
+    """Return stored screw positions."""
+    return dbase.get("screws", {})
+
+
+@app.get("/image")
+def get_image():
+    """Return the stored camera image or 404 if missing."""
+    entry = dbase.get("camera_image")
+    if not entry:
+        return Response(status_code=404)
+    data = base64.b64decode(entry.get("data", ""))
+    fmt = entry.get("format", "png")
+    return Response(content=data, media_type=f"image/{fmt}")
+
+
+@app.get("/", response_class=HTMLResponse)
+def index():
+    """Display the image with simple screw annotations."""
+    return """
+    <html>
+      <body>
+        <h1>Detection Viewer</h1>
+        <canvas id=\"canvas\"></canvas>
+        <pre id=\"coords\"></pre>
+        <script>
+          async function load() {
+            const imgResp = await fetch('/image');
+            if (!imgResp.ok) {
+              document.body.innerHTML += '<p>No image available</p>';
+              return;
+            }
+            const blob = await imgResp.blob();
+            const img = await createImageBitmap(blob);
+            const canvas = document.getElementById('canvas');
+            canvas.width = img.width;
+            canvas.height = img.height;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(img, 0, 0);
+            const screws = await fetch('/screws').then(r => r.json());
+            document.getElementById('coords').textContent = JSON.stringify(screws, null, 2);
+            ctx.fillStyle = 'red';
+            ctx.strokeStyle = 'red';
+            for (const id in screws) {
+              const s = screws[id];
+              const x = s.x; const y = s.y;
+              ctx.beginPath();
+              ctx.arc(x, y, 5, 0, 2*Math.PI);
+              ctx.fill();
+              ctx.fillText(id, x + 6, y + 6);
+            }
+          }
+          load();
+        </script>
+      </body>
+    </html>
+    """


### PR DESCRIPTION
## Summary
- add FastAPI app to display stored camera image with screw annotations
- add `dimonta web results` CLI command to launch the viewer
- document the YOLO result viewer in README

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ceca15e8c83319d8d660b3f6fb09e