### PR TITLE
Use sample image when RealSense camera unavailable

### DIFF
--- a/docs/realsense.md
+++ b/docs/realsense.md
@@ -11,4 +11,4 @@ To use a physical camera:
 3. The captured image is stored in the database under the key `camera_image`.
 
 If no camera is available, omit the parameter or set `use_camera=false`.
-A small dummy image will be written to the database so dependent skills can still run.
+The skill will store the first PNG image found in its directory (or an optional `sample_dir`) in the database so dependent skills can still run.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,10 +1,11 @@
 # Skill Documentation
 
-## CaptureRealSenseImage (v1.1.0)
+## CaptureRealSenseImage (v1.2.0)
 Capture an image from an Intel RealSense camera and store it in the database.
 
 **Inputs**
-- `use_camera`: Set to `true` to read from a RealSense camera, otherwise a dummy image is produced
+- `use_camera`: Set to `true` to read from a RealSense camera, otherwise a sample PNG is stored
+- `sample_dir`: Directory containing PNG images to use when the camera is unavailable
 
 **Outputs**
 - `image_key`: Database key where the image is stored


### PR DESCRIPTION
## Summary
- Load first PNG from configurable directory when RealSense camera is missing
- Document sample image usage for `CaptureRealSenseImage`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cefc58a14833196491596a5bd48f2