### PR TITLE
Add FastAPI server, XML gateway and tooling for skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ dimonta web results --port 8001
 Open ``http://localhost:8001`` to view the image with annotated detections and
 their coordinates.
 
+### Headless Server
+
+Run the FastAPI based server to execute skills via HTTP, WebSocket or XML:
+
+```bash
+uvicorn di_core.server:app --reload
+```
+
+`GET /skills` lists all registered skills. To run a skill send a JSON payload
+to `POST /execute` or connect to the WebSocket endpoint at
+`ws://localhost:8000/ws/execute`. A minimal HTML client is available at
+`web/index.html`.
+
 ## Demo Ideas
 
 - **Manual Full Screw Workflow** – Run a sequence of skills to detect screws,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "dimonta-core-mvp"
+name = "dimonta-core"
 version = "0.1.0"
 description = "di.core MVP with internal skill communication"
 authors = [{ name = "di.monta" }]
@@ -20,8 +20,8 @@ dependencies = [
 
 [project.scripts]
 dimonta = "di_core.cli:app"
-skill-docs = "di_skills.docgen:main"
+skill-docs = "tools.skill_docs:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["di_core", "di_skills", "di_base_client", "di_skills.skills", "di_skills.templates.python"]
+packages = ["di_core", "di_skills", "di_base_client", "di_skills.skills", "di_skills.templates.python", "tools"]

--- a/src/di_core/cli.py
+++ b/src/di_core/cli.py
@@ -16,7 +16,6 @@ web_app = typer.Typer(help="Web utilities")
 
 app.add_typer(skills_app, name="skills")
 app.add_typer(db_app, name="db")
-web_app = typer.Typer(help="Web utilities")
 app.add_typer(web_app, name="web")
 
 @skills_app.command("list")
@@ -87,9 +86,6 @@ def web_results(host: str = "localhost", port: int = 8001):
     from di_core.results_web import app as webapp
 
     uvicorn.run(webapp, host=host, port=port)
-
-app.add_typer(web_app, name="web")
-
 
 def main() -> None:
     app()

--- a/src/di_core/server.py
+++ b/src/di_core/server.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import uuid
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+
+from di_core.api import ExecuteRequest
+from di_core.registry import registry
+from di_core.runtime import Runtime
+from di_core.xml_gateway import xml_router
+
+# register example skill via side-effect
+from di_skills.skills import unscrew as _  # noqa: F401
+
+app = FastAPI(title="di.core skill runtime")
+app.include_router(xml_router)
+
+runtime = Runtime()
+
+
+@app.get("/skills")
+def list_skills():
+    """Return list of registered skill names."""
+    return registry.list()
+
+
+@app.post("/execute")
+async def execute(req: ExecuteRequest):
+    """Execute a skill and collect all status events."""
+    events = []
+    async for st in runtime.execute(req):
+        events.append(st.dict())
+    return {"instance_id": req.instance_id, "events": events}
+
+
+@app.post("/abort/{instance_id}")
+def abort(instance_id: str):
+    """Abort a running skill instance."""
+    ok = runtime.abort(instance_id)
+    return {"aborted": ok}
+
+
+@app.websocket("/ws/execute")
+async def ws_execute(ws: WebSocket):
+    await ws.accept()
+    try:
+        data = await ws.receive_json()
+        if "instance_id" not in data:
+            data["instance_id"] = str(uuid.uuid4())
+        req = ExecuteRequest(**data)
+        async for st in runtime.execute(req):
+            await ws.send_json(st.dict())
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await ws.close()

--- a/src/di_core/xml_gateway.py
+++ b/src/di_core/xml_gateway.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import uuid
+import xml.etree.ElementTree as ET
+from fastapi import APIRouter, Body, Response
+
+from di_core.api import ExecuteRequest
+from di_core.runtime import Runtime
+
+# local runtime for XML commands
+_runtime = Runtime()
+
+xml_router = APIRouter(prefix="/xml")
+
+
+@xml_router.post("/command")
+async def xml_command(payload: str = Body(..., media_type="application/xml")):
+    root = ET.fromstring(payload)
+    skill = root.attrib.get("skill", "")
+    instance_id = root.attrib.get("instanceId") or str(uuid.uuid4())
+    params: dict[str, str] = {}
+    for p in root.findall("Param"):
+        name = p.attrib.get("name")
+        value = p.attrib.get("value", "")
+        if name:
+            params[name] = value
+    req = ExecuteRequest(skill_name=skill, instance_id=instance_id, params=params)
+    events = []
+    async for st in _runtime.execute(req):
+        events.append(st)
+    status = ET.Element("DiMontaStatus")
+    inst = ET.SubElement(status, "Instance")
+    inst.text = instance_id
+    for e in events:
+        ev = ET.SubElement(status, "Event", phase=e.phase, progress=str(e.progress_pct))
+        ev.text = e.message
+    xml_resp = ET.tostring(status, encoding="utf-8").decode()
+    return Response(content=xml_resp, media_type="application/xml")

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for di.core"""

--- a/src/tools/skill_docs.py
+++ b/src/tools/skill_docs.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from di_core.registry import registry
+from di_skills import skills as _  # noqa: F401 ensure skills are registered
+
+
+def main() -> None:
+    lines = ["| Name | Version | Description |", "| --- | --- | --- |"]
+    for name in registry.list():
+        cls = registry.get(name)
+        doc = (cls.__doc__ or "").strip().replace("\n", " ")
+        ver = getattr(cls, "VERSION", "")
+        lines.append(f"| {name} | {ver} | {doc} |")
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>di.monta Skill Runner</title>
+</head>
+<body>
+  <h1>Run Skill</h1>
+  <label>Skill: <input id="skill" value="Unscrew"/></label><br/>
+  <label>Params JSON:<br/>
+    <textarea id="params" rows="4" cols="40">{"target_id": "A1"}</textarea>
+  </label><br/>
+  <button id="run">Run</button>
+  <pre id="log"></pre>
+  <script>
+    const runBtn = document.getElementById('run');
+    const log = document.getElementById('log');
+    runBtn.onclick = () => {
+      log.textContent = '';
+      const ws = new WebSocket('ws://localhost:8000/ws/execute');
+      ws.onopen = () => {
+        let params = {};
+        try {
+          const txt = document.getElementById('params').value || '{}';
+          params = JSON.parse(txt);
+        } catch (e) {
+          alert('Invalid JSON in params');
+          ws.close();
+          return;
+        }
+        ws.send(JSON.stringify({skill_name: document.getElementById('skill').value, params: params}));
+      };
+      ws.onmessage = (ev) => {
+        log.textContent += ev.data + '\n';
+      };
+      ws.onclose = () => {
+        log.textContent += '[closed]\n';
+      };
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI server with HTTP, WebSocket and XML interfaces for running skills
- provide minimal HTML client for triggering skills via WebSocket
- add Markdown skill docs generator and expose via `skill-docs`
- polish CLI subcommand registration and project metadata

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python -m tools.skill_docs | head`


------
https://chatgpt.com/codex/tasks/task_e_689cf6b684d08331a9fc0734f32b178b